### PR TITLE
Reenable Scroll to current week (#1152)

### DIFF
--- a/assets/src/components/AssignmentGoalInput.js
+++ b/assets/src/components/AssignmentGoalInput.js
@@ -4,6 +4,7 @@ import Grid from '@material-ui/core/Grid'
 import Button from '@material-ui/core/Button'
 import StyledTextField from './StyledTextField'
 import debounce from 'lodash.debounce'
+import usePrevious from '../hooks/usePreviousValue'
 
 const styles = ({
   goalGradeInput: {
@@ -17,20 +18,23 @@ function AssignmentGoalInput (props) {
     maxPossibleGrade,
     goalGrade,
     setGoalGrade,
+    setGoalGradePrev,
     handleClearGoalGrades,
     mathWarning,
     classes
   } = props
 
   const [goalGradeInternal, setGoalGradeInternal] = useState(goalGrade)
+  const prevGrade = usePrevious(goalGrade)
   const debouncedGoalGrade = useRef(debounce(q => setGoalGrade(q), 500)).current
-
   const updateGoalGradeInternal = (grade) => {
+    setGoalGradePrev(prevGrade)
     debouncedGoalGrade(grade)
     setGoalGradeInternal(grade)
   }
 
   useEffect(() => {
+    setGoalGradePrev(prevGrade)
     setGoalGradeInternal(goalGrade)
   }, [goalGrade])
 

--- a/assets/src/components/AssignmentGoalInput.js
+++ b/assets/src/components/AssignmentGoalInput.js
@@ -48,7 +48,7 @@ function AssignmentGoalInput (props) {
           value={goalGradeInternal}
           label={
             mathWarning
-              ? 'Math may no longer add up'
+              ? 'Scores no longer match goal'
               : goalGrade > 100
                 ? 'Over 100%'
                 : goalGrade > maxPossibleGrade

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -230,69 +230,69 @@ function AssignmentTable (props) {
   }
 
   return (
-    <RootRef rootRef={tableRef}>
-      <div>
-        <Grid container className={classes.filterArea}>
-          <Grid item xs={12} sm={4}>
-            <FormControl className={classes.formControl}>
-              <InputLabel>Filter by Type</InputLabel>
-              <Select
-                labelId='assignment-group-checkbox-label'
-                id='assignment-group-mutiple-checkbox'
-                multiple
-                value={assignmentGroupFilterArray}
-                onChange={e => setAssignmentGroupFilterArray(e.target.value)}
-                input={<Input />}
-                renderValue={(selected) => selected.join(', ')}
-                MenuProps={MenuProps}
-                width='250px'
-              >
-                {assignmentGroupNames.map((name) => (
-                  <MenuItem key={name} value={name}>
-                    <Checkbox checked={assignmentGroupFilterArray.indexOf(name) > -1} />
-                    <ListItemText primary={name} />
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={3}>
-            <FormControl className={classes.formControl}>
-              <InputLabel>Filter by Name</InputLabel>
-              <Input value={assignmentNameFilter} placeholder='Filter by name...' onChange={e => setAssignmentNameFilter(e.target.value)} />
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={3}>
-            <FormControl className={classes.formControl}>
-              <InputLabel>Filter by Status</InputLabel>
-              <Select
-                labelId='assignment-status-checkbox-label'
-                id='assignment-status-mutiple-checkbox'
-                multiple
-                value={assignmentStatusFilterArray}
-                onChange={e => setAssignmentStatusFilterArray(e.target.value)}
-                input={<Input />}
-                renderValue={(selected) => selected.join(', ')}
-                MenuProps={MenuProps}
-                width='250px'
-              >
-                {assignmentStatusNames.map((name) => (
-                  <MenuItem key={name} value={name}>
-                    <Checkbox checked={assignmentStatusFilterArray.indexOf(name) > -1} />
-                    <ListItemText primary={name} />
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={1}>
-            <Tooltip title='Clear filters' placement='bottom' enterDelay={500}>
-              <FormControl className={classes.formControl}>
-                <Button size='small' variant='contained' onClick={() => clearFilters()} disabled={filtersAreClear}><ClearIcon /></Button>
-              </FormControl>
-            </Tooltip>
-          </Grid>
+    <div>
+      <Grid container className={classes.filterArea}>
+        <Grid item xs={12} sm={4}>
+          <FormControl className={classes.formControl}>
+            <InputLabel>Filter by Type</InputLabel>
+            <Select
+              labelId='assignment-group-checkbox-label'
+              id='assignment-group-mutiple-checkbox'
+              multiple
+              value={assignmentGroupFilterArray}
+              onChange={e => setAssignmentGroupFilterArray(e.target.value)}
+              input={<Input />}
+              renderValue={(selected) => selected.join(', ')}
+              MenuProps={MenuProps}
+              width='250px'
+            >
+              {assignmentGroupNames.map((name) => (
+                <MenuItem key={name} value={name}>
+                  <Checkbox checked={assignmentGroupFilterArray.indexOf(name) > -1} />
+                  <ListItemText primary={name} />
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </Grid>
+        <Grid item xs={12} sm={3}>
+          <FormControl className={classes.formControl}>
+            <InputLabel>Filter by Name</InputLabel>
+            <Input value={assignmentNameFilter} placeholder='Filter by name...' onChange={e => setAssignmentNameFilter(e.target.value)} />
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={3}>
+          <FormControl className={classes.formControl}>
+            <InputLabel>Filter by Status</InputLabel>
+            <Select
+              labelId='assignment-status-checkbox-label'
+              id='assignment-status-mutiple-checkbox'
+              multiple
+              value={assignmentStatusFilterArray}
+              onChange={e => setAssignmentStatusFilterArray(e.target.value)}
+              input={<Input />}
+              renderValue={(selected) => selected.join(', ')}
+              MenuProps={MenuProps}
+              width='250px'
+            >
+              {assignmentStatusNames.map((name) => (
+                <MenuItem key={name} value={name}>
+                  <Checkbox checked={assignmentStatusFilterArray.indexOf(name) > -1} />
+                  <ListItemText primary={name} />
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={1}>
+          <Tooltip title='Clear filters' placement='bottom' enterDelay={500}>
+            <FormControl className={classes.formControl}>
+              <Button size='small' variant='contained' onClick={() => clearFilters()} disabled={filtersAreClear}><ClearIcon /></Button>
+            </FormControl>
+          </Tooltip>
+        </Grid>
+      </Grid>
+      <RootRef rootRef={tableRef}>
         <TableContainer className={classes.container}>
           <MTable stickyHeader ref={tableRef}>
             <TableHead>
@@ -469,8 +469,8 @@ function AssignmentTable (props) {
             </TableBody>
           </MTable>
         </TableContainer>
-      </div>
-    </RootRef>
+      </RootRef>
+    </div>
   )
 }
 

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -125,11 +125,16 @@ function AssignmentTable (props) {
 
   const [filtersAreClear, setFiltersAreClear] = useState(true)
 
+  const [previousWeek, setPreviousWeek] = useState()
+
+  const [weeksPresent, setWeeksPresentInCollection] = useState([])
+
   const tableRef = useRef(null)
-  const currentWeekRow = useRef(null)
+  const previousWeekRow = useRef(null)
 
   const currentDate = new Date()
   const currentWeek = calculateWeekOffset(dateStart, currentDate)
+  // const previousWeek = currentWeek - 1
 
   const maxPercentOfFinalGrade = Math.max(
     ...assignments.map(({ percentOfFinalGrade }) => percentOfFinalGrade)
@@ -164,19 +169,27 @@ function AssignmentTable (props) {
 
   // this effect scrolls to current week of assignments if it exists
   useEffect(() => {
-    if (currentWeekRow.current) {
-      const tableHeaderOffset = 120
+    if (previousWeekRow.current) {
+      const tableHeaderOffset = -74 // Manually measured height of table header row
       tableRef.current.scrollTo({
-        top: currentWeekRow.current.offsetTop - tableHeaderOffset,
+        top: previousWeekRow.current.offsetTop - tableHeaderOffset,
         behavior: 'smooth'
       })
     }
-  }, [currentWeekRow.current])
+  }, [previousWeekRow.current])
 
   useEffect(() => {
     const allGroupNames = assignments.map(ag => ag.assignmentGroup.name)
     const uniqueGroupNames = [...new Set(allGroupNames)].sort()
     setAssignmentGroupNames(uniqueGroupNames)
+  }, [assignments])
+
+  useEffect(() => {
+    setWeeksPresentInCollection([...new Set(assignments.map(a => a.week))].sort((a, b) => { return a - b }))
+    const indexOfCurrentWeek = weeksPresent.indexOf(currentWeek)
+    if (indexOfCurrentWeek > 0) {
+      setPreviousWeek(weeksPresent[indexOfCurrentWeek - 1])
+    }
   }, [assignments])
 
   useEffect(() => {
@@ -323,8 +336,8 @@ function AssignmentTable (props) {
                 filteredAssignments
                   .map((a, key) => (
                     <ConditionalWrapper
-                      condition={a.week === currentWeek}
-                      wrapper={children => <RootRef rootRef={currentWeekRow} key={key}>{children}</RootRef>}
+                      condition={a.week === previousWeek}
+                      wrapper={children => <RootRef rootRef={previousWeekRow} key={key}>{children}</RootRef>}
                       key={key}
                     >
                       <TableRow key={key}>

--- a/assets/src/components/AssignmentTable.js
+++ b/assets/src/components/AssignmentTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import Button from '@material-ui/core/Button'
 import Checkbox from '@material-ui/core/Checkbox'
@@ -127,14 +127,13 @@ function AssignmentTable (props) {
 
   const [previousWeek, setPreviousWeek] = useState()
 
-  const [weeksPresent, setWeeksPresentInCollection] = useState([])
+  const weeksPresent = useRef([])
 
   const tableRef = useRef(null)
   const previousWeekRow = useRef(null)
 
   const currentDate = new Date()
   const currentWeek = calculateWeekOffset(dateStart, currentDate)
-  // const previousWeek = currentWeek - 1
 
   const maxPercentOfFinalGrade = Math.max(
     ...assignments.map(({ percentOfFinalGrade }) => percentOfFinalGrade)
@@ -170,13 +169,13 @@ function AssignmentTable (props) {
   // this effect scrolls to current week of assignments if it exists
   useEffect(() => {
     if (previousWeekRow.current) {
-      const tableHeaderOffset = -74 // Manually measured height of table header row
+      const tableHeaderOffset = -50 // Manually measured height of table header row
       tableRef.current.scrollTo({
         top: previousWeekRow.current.offsetTop - tableHeaderOffset,
         behavior: 'smooth'
       })
     }
-  }, [previousWeekRow.current])
+  }, [previousWeekRow.current, filteredAssignments])
 
   useEffect(() => {
     const allGroupNames = assignments.map(ag => ag.assignmentGroup.name)
@@ -185,10 +184,14 @@ function AssignmentTable (props) {
   }, [assignments])
 
   useEffect(() => {
-    setWeeksPresentInCollection([...new Set(assignments.map(a => a.week))].sort((a, b) => { return a - b }))
-    const indexOfCurrentWeek = weeksPresent.indexOf(currentWeek)
-    if (indexOfCurrentWeek > 0) {
-      setPreviousWeek(weeksPresent[indexOfCurrentWeek - 1])
+    const allWeeks = [...new Set(assignments.map(a => a.week))].sort((a, b) => { return a - b })
+    if (allWeeks.length > 0) {
+      weeksPresent.current = allWeeks
+      const firstItem = weeksPresent.current.indexOf(0) === -1 ? weeksPresent.current.indexOf(1) : weeksPresent.current.indexOf(0)
+      const indexOfCurrentWeek = weeksPresent.current.indexOf(currentWeek)
+      if (indexOfCurrentWeek > 0 && firstItem !== indexOfCurrentWeek) {
+        setPreviousWeek(weeksPresent.current[indexOfCurrentWeek - 1])
+      }
     }
   }, [assignments])
 

--- a/assets/src/containers/AssignmentPlanningV2.js
+++ b/assets/src/containers/AssignmentPlanningV2.js
@@ -74,6 +74,7 @@ function AssignmentPlanningV2 (props) {
 
   const [assignments, setAssignments] = useState([])
   const [goalGrade, setGoalGrade] = useState('')
+  const [goalGradePrev, setGoalGradePrev] = useState('')
   const [userSetting, setUserSetting] = useState({})
   const [settingChanged, setSettingChanged] = useState(false)
 
@@ -100,6 +101,9 @@ function AssignmentPlanningV2 (props) {
     data,
     assignments,
     goalGrade,
+    goalGradePrev,
+    currentGrade,
+    maxPossibleGrade,
     setAssignments,
     setUserSetting
   })
@@ -123,6 +127,7 @@ function AssignmentPlanningV2 (props) {
 
   const handleClearGoalGrades = () => {
     setAssignments(clearGoals(assignments))
+    setGoalGradePrev(goalGrade)
     setGoalGrade('')
     setSettingChanged(true)
   }
@@ -194,6 +199,9 @@ function AssignmentPlanningV2 (props) {
                           currentGrade={currentGrade}
                           goalGrade={goalGrade}
                           maxPossibleGrade={maxPossibleGrade}
+                          setGoalGradePrev={grade => {
+                            setGoalGradePrev(grade)
+                          }}
                           setGoalGrade={grade => {
                             setSettingChanged(true)
                             setGoalGrade(grade)

--- a/assets/src/containers/DashboardAppBar.js
+++ b/assets/src/containers/DashboardAppBar.js
@@ -61,10 +61,10 @@ function DashboardAppBar (props) {
           >
             <MenuIcon />
           </IconButton>
-          <Link tabIndex={-1} to='/courses/' className={classes.homeButton}>
+          <Link to='/courses/' className={classes.homeButton}>
             My Learning Analytics:
           </Link>
-          <Link tabIndex={-1} to={`/courses/${courseId}`} className={classes.homeButton}>
+          <Link to={`/courses/${courseId}`} className={classes.homeButton}>
             {courseName}
           </Link>
           <div className={classes.grow} />

--- a/assets/src/hooks/usePreviousValue.js
+++ b/assets/src/hooks/usePreviousValue.js
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react'
+
+const usePrevious = (value) => {
+  const ref = useRef()
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref.current
+}
+
+export default usePrevious

--- a/assets/src/hooks/useSyncAssignmentAndGoalGrade.js
+++ b/assets/src/hooks/useSyncAssignmentAndGoalGrade.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { calculateAssignmentGoalsFromCourseGoal, sumAssignmentGoalGrade } from '../util/assignment'
+import { roundToXDecimals } from '../util/math'
 
 // this effect is used to keep the goal of the course and assignments "in sync"
 // run if goalGrade changes, or if the sum of goal grades set by user changes
@@ -8,6 +9,9 @@ const useSyncAssignmentAndGoalGrade =
     data,
     assignments,
     goalGrade,
+    goalGradePrev,
+    currentGrade,
+    maxPossibleGrade,
     setAssignments,
     setUserSetting
   }) => {
@@ -22,18 +26,29 @@ const useSyncAssignmentAndGoalGrade =
     useEffect(() => {
       const assignmentsSetByUser = assignments
         .filter(a => a.goalGradeSetByUser)
-        .map(({ id, goalGradeSetByUser, goalGrade }) => (
+        .map(({ id, goalGradeSetByUser, goalGrade, goalGradePrev }) => (
           {
             assignmentId: id,
             goalGradeSetByUser,
-            goalGrade
+            goalGrade,
+            goalGradePrev
           }
         ))
 
-      setUserSetting({
-        goalGrade,
-        assignments: assignmentsSetByUser
-      })
+      const userSetting = () => {
+        const setting = {
+          goalGrade,
+          currentGrade: roundToXDecimals(currentGrade, 1),
+          maxPossible: roundToXDecimals(maxPossibleGrade, 1),
+          assignments: assignmentsSetByUser
+        }
+        if (goalGradePrev !== '') {
+          setting.goalGradePrev = roundToXDecimals(goalGradePrev, 1)
+        }
+        return setting
+      }
+
+      setUserSetting(userSetting)
 
       if (goalGrade !== '') {
         setAssignments(

--- a/assets/src/hooks/useUserAssignmentSetting.js
+++ b/assets/src/hooks/useUserAssignmentSetting.js
@@ -26,6 +26,7 @@ const useUserAssignmentSetting =
               if (assignmentSetting) {
                 a.goalGrade = assignmentSetting.goalGrade
                 a.goalGradeSetByUser = assignmentSetting.goalGradeSetByUser
+                a.goalGradePrev = assignmentSetting.goalGradePrev
               }
               return a
             })

--- a/assets/src/util/assignment.js
+++ b/assets/src/util/assignment.js
@@ -34,10 +34,12 @@ const setAssignmentGoalGrade = (assignmentId, assignments, goalGrade) => {
     return assignments
   } else {
     const key = assignments.indexOf(assignment[0])
+    const prevGoalGrade = assignments[key].goalGrade
     return [
       ...assignments.slice(0, key),
       {
         ...assignments[key],
+        goalGradePrev: prevGoalGrade === '' ? '' : roundToXDecimals(Number(prevGoalGrade), 1),
         goalGrade: goalGrade === '' ? '' : roundToXDecimals(Number(goalGrade), 3),
         goalGradeSetByUser: !!goalGrade
       },


### PR DESCRIPTION
#1147 This change scrolls to current week and exactly to current week visibility.

In order to manually trigger current week changes this is how you do it

```
const today = new Date()
const currentDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 14) // goes back add plus to future weeks
```

get the latest from the current master as some of the changes made will reflect that

Test cases:
1. When user never set a goal grade
2. user set a goal grade
3. User clear goal grade

Try testing in all 3 scenarios